### PR TITLE
Add support for 64-bit ticks for ARM Cortex M0 and M33

### DIFF
--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -69,6 +69,9 @@ typedef unsigned long    UBaseType_t;
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
+#elif (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS)
+    typedef uint64_t        TickType_t;
+    #define portMAX_DELAY  (TickType_t)0xffffffffffffffffULL
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -69,9 +69,9 @@ typedef unsigned long    UBaseType_t;
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
-#elif (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS)
-    typedef uint64_t        TickType_t;
-    #define portMAX_DELAY  (TickType_t)0xffffffffffffffffULL
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS )
+    typedef uint64_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffffffffffffffffULL
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -84,6 +84,9 @@ typedef unsigned long    UBaseType_t;
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
+#elif (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS)
+    typedef uint64_t        TickType_t;
+    #define portMAX_DELAY  (TickType_t)0xffffffffffffffffULL
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -84,9 +84,9 @@ typedef unsigned long    UBaseType_t;
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
-#elif (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS)
-    typedef uint64_t        TickType_t;
-    #define portMAX_DELAY  (TickType_t)0xffffffffffffffffULL
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS )
+    typedef uint64_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffffffffffffffffULL
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -560,7 +560,7 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
 void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 {
     BlockLink_t * pxBlock;
-    size_t xBlocks = 0, xMaxSize = 0, xMinSize = portMAX_DELAY; /* portMAX_DELAY used as a portable way of getting the maximum value. */
+    size_t xBlocks = 0, xMaxSize = 0, xMinSize = SIZE_MAX;
 
     vTaskSuspendAll();
     {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Adds ability to use configTICK_TYPE_WIDTH_IN_BITS = TICK_TYPE_WIDTH_64_BITS to the Cortex-M0 and Cortex-M33 ports

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Use 
`#define configTICK_TYPE_WIDTH_IN_BITS TICK_TYPE_WIDTH_64_BITS`
in a project using port `GCC_ARM_CM0` or `GCC_ARM_CM33_NTZ_NONSECURE`. 

The only port that currently handles it is `GCC_ARM_CM4F`.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
